### PR TITLE
Fix the function signature comment

### DIFF
--- a/metasync.js
+++ b/metasync.js
@@ -101,8 +101,9 @@ metasync.filter = function(coll, predicate, done) {
   });
 };
 
-// Asynchronous find function
-// find :: (a -> Boolean) -> [a] -> (a -> Void)
+// Asynchronous find
+
+// find :: [a] -> (a -> (Boolean -> Void) -> Void) -> (a -> Void)
 metasync.find = function(array, predicate, done) {
   var i = 0,
       len = array.length;
@@ -122,4 +123,4 @@ metasync.find = function(array, predicate, done) {
 
   if (len > 0) next();
   else done();
-}
+};


### PR DESCRIPTION
- Fix the signature comment for `metasync.find` function.
- [Codestyle] blank line after comment ("Asynchronous find function")
- [Codestyle] fix missing semicolon at the end