### PR TITLE
Added isomorphism between callback and metacallback categories

### DIFF
--- a/metasync.js
+++ b/metasync.js
@@ -574,3 +574,13 @@ metasync.timeout = (timeout, asyncFunction, doneFunction) => {
     }
   });
 };
+
+// Wrap metacallback to common callback
+//    callback - function to wrap
+metasync.fromMetaCallback = callback => (err, data) => callback(err || data);
+
+// Wrap common callback to metacallback
+//    callback - function to wrap
+metasync.toMetaCallback   = callback => dataE => dataE instanceof Error
+                                               ? callback(dataE)
+                                               : callback(null, dataE);


### PR DESCRIPTION
After using parallel and sequential function I admitted common transforms of callbacks from (err, data) to (err || data).
I propose to create category "metacallback" for this functions. And functions that allows to convert between common callbacks and these special callbacks.

P.S. The best option, as see my eyes, to use this kind of functions everywhere to save ease of using metasync library. 