### PR TITLE
Implement chainable async array transformers

### DIFF
--- a/array-utils.js
+++ b/array-utils.js
@@ -1,0 +1,167 @@
+'use strict';
+
+const arrayUtils = {};
+module.exports = arrayUtils;
+
+arrayUtils.map = (
+  // Asynchronous map
+  items, // incoming array
+  callback, // function to be executed for each value in the array
+  // current - current element being processed in the array
+  // callback - callback for returning value back to function map
+  //   err - error or null
+  //   value - result
+  done // callback function on done
+  // err - error or null
+  // data - result if !err
+) => {
+  const result = [];
+  let hadError = false;
+  let count = 0;
+  items.forEach((item, index) => {
+    callback(item, (err, value) => {
+      if (err) {
+        hadError = true;
+        return done(err);
+      }
+      if (hadError) return;
+      result[index] = value;
+      if (++count === items.length) {
+        done(null, result);
+      }
+    });
+  });
+};
+
+arrayUtils.filter = (
+  // Asynchrous filter (iterate parallel)
+  // filter :: [a] -> (a -> (Boolean -> Void) -> Void) -> ([a] -> Void)
+  items, // incoming array
+  fn, // function(value, callback)
+  // value - item from items array
+  // callback - callback function(accepted)
+  //   accepted - true/false returned from fn
+  done // on done function(result)
+  // result - filtered array
+) => {
+  let result = [];
+  let counter = 0;
+
+  function finish() {
+    // Callbacks might be called in any possible order,
+    // hence sort the filtered array
+    // by element's index in the original itemsection
+    result.sort((x, y) => x.index - y.index);
+
+    // Only value is needed in resulting array
+    result = result.map(x => x.value);
+
+    // Return a result using callback;
+    if (done) done(result);
+  }
+
+  items.forEach((value, index) => {
+    fn(value, (accepted) => {
+      if (accepted) result.push({ index, value });
+      if (++counter === items.length) finish();
+    });
+  });
+};
+
+arrayUtils.reduce = (
+  // Asynchronous reduce
+  items, //   items - incoming array
+  callback, //   callback - function to be executed for each value in the array
+  //     previous - value previously returned in the last iteration
+  //     current - current element being processed in the array
+  //     callback - callback for returning value back to function reduce
+  //     counter - the index of the current element being processed in the array
+  //     items - the array reduce was called upon
+  done, //   done - callback function on done
+  //     err - error or null
+  //     data - result if !err
+  initial // optional value to be used as first arpument in first iteration
+) => {
+  let counter = typeof(initial) === 'undefined' ? 1 : 0;
+  let previous = counter === 1 ? items[0] : initial;
+  let current = items[counter];
+
+  function response(err, data) {
+    if (err || counter === items.length - 1) {
+      if (done) done(err, data);
+      return;
+    }
+    counter++;
+    previous = data;
+    current = items[counter];
+    callback(previous, current, response, counter, items);
+  }
+
+  callback(previous, current, response, counter, items);
+};
+
+arrayUtils.each = (
+  // Asynchronous each (iterate in parallel)
+  items, // incoming array
+  fn, // function(value, callback)
+  // value - item from items array
+  // callback - callback function(accepted)
+  //   err - instance of Error or null
+  done // on `done` function(result)
+  // err - instance of Error or null
+) => {
+  let counter = 0;
+  let finished = false;
+  const len = items.length;
+
+  if (len < 1) {
+    if (done) done();
+    return;
+  }
+  items.forEach((item) => {
+    fn(item, (err) => {
+      if (err instanceof Error) {
+        if (!finished) {
+          if (done) done(err);
+        }
+        finished = true;
+      } else {
+        counter++;
+        if (counter >= len) {
+          if (done) done();
+        }
+      }
+    });
+  });
+};
+
+arrayUtils.series = (
+  // Asynchronous series
+  items, // incoming array
+  fn, // function(value, callback)
+  // value - item from items array
+  // callback - callback function(accepted)
+  //   err - instance of Error or null
+  done // on done function(result)
+  // err - instance of Error or null
+) => {
+  let i = -1;
+  const len = items.length;
+
+  function next() {
+    i++;
+    if (i >= len) {
+      if (done) done();
+      return;
+    }
+    fn(items[i], (err) => {
+      if (err instanceof Error) {
+        if (done) done(err);
+        return;
+      }
+      setImmediate(next);
+    });
+  }
+
+  next();
+};

--- a/async-array.js
+++ b/async-array.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const arrayUtils = require('./array-utils');
+
+class AsyncArray {
+  constructor(array) {
+    this._promise = Promise.resolve(array);
+  }
+
+  then(fn) {
+    return this._promise.then(fn);
+  }  // eslint-disable-line brace-style
+  // (^ probably a bug in ESLint)
+
+  catch(fn) {
+    return this._promise.catch(fn);
+  }
+
+  map(fn) {
+    this._update((array, resolve, reject) => {
+      arrayUtils.map(array, fn, (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+    return this;
+  }
+
+  filter(fn) {
+    this._update((array, resolve) => {
+      arrayUtils.filter(array, fn, (result) => {
+        resolve(result);
+      });
+    });
+    return this;
+  }
+
+  reduce(fn, initial) {
+    this._update((array, resolve, reject) => {
+      arrayUtils.reduce(array, fn, (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      }, initial);
+    });
+    return this._promise;
+  }
+
+  each(fn) {
+    this._update((array, resolve, reject) => {
+      arrayUtils.each(array, fn, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+    return this._promise;
+  }
+
+  series(fn) {
+    this._update((array, resolve, reject) => {
+      arrayUtils.series(array, fn, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+    return this._promise;
+  }
+
+  find(fn) {
+    this._update((array, resolve) => {
+      arrayUtils.find((array, fn, (result) => {
+        resolve(result);
+      }));
+    });
+    return this._promise;
+  }
+
+  _update(fn) {
+    this._promise = this._promise.then((array) => (
+      new Promise((resolve, reject) => {
+        fn(array, resolve, reject);
+      })
+    ));
+  }
+}
+
+module.exports = AsyncArray;

--- a/chain-example.js
+++ b/chain-example.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('assert');
+const metasync = require('.');
+
+// TODO(aqrln): test all the methods. Though AsyncArray just wraps
+// array-related metasync functions in uniform fashion, and they are covered by
+// their own tests (so if they work correctly and a couple of AsyncArray
+// methods work properly, all of its methods should do too), extra tests are
+// never superfluous.
+
+console.log('Chaining test');
+
+metasync.for([1, 2, 3, 4]).filter((item, cb) => {
+  process.nextTick(cb, item % 2 === 0);
+}).map((item, cb) => {
+  process.nextTick(cb, null, item * 2);
+}).reduce((a, b, cb) => {
+  process.nextTick(cb, null, a + b);
+}).then((result) => {
+  console.log('Chaining test done: ' + result);
+  assert.strictEqual(result, 12);  // 2 * 2 + 4 * 2
+}).catch((error) => {
+  const description = error.stack || 'Error: ' + error.toString();
+  console.error(description);
+  process.exit(1);
+});

--- a/examples.js
+++ b/examples.js
@@ -485,6 +485,14 @@ function timeoutTest() {
   });
 }
 
+function chainTest() {
+  // Just to make sure we don't forget to merge the tests. There's some bug in
+  // metasync.composition so part of tests, including this one, are not run.
+  // As a temporary workaround, you can run it via
+  //   $ node chain-example
+  require('./chain-example');
+}
+
 // Run tests
 
 metasync.composition([
@@ -504,7 +512,8 @@ metasync.composition([
   concurrentQueuePauseResumeStopTest,
   throttleTest,
   mapTest,
-  timeoutTest
+  timeoutTest,
+  chainTest
 ], () => {
   console.log('All tests done');
 });

--- a/metasync.js
+++ b/metasync.js
@@ -1,7 +1,12 @@
 'use strict';
 
+const arrayUtils = require('./array-utils');
+const AsyncArray = require('./async-array');
+
 const metasync = {};
 module.exports = metasync;
+
+Object.assign(metasync, arrayUtils);
 
 metasync.composition = (
   // Functional Asynchronous Composition
@@ -347,41 +352,6 @@ metasync.ConcurrentQueue.prototype.stop = function() {
   };
 };
 
-metasync.filter = (
-  // Asynchrous filter (iterate parallel)
-  // filter :: [a] -> (a -> (Boolean -> Void) -> Void) -> ([a] -> Void)
-  items, // incoming array
-  fn, // function(value, callback)
-  // value - item from items array
-  // callback - callback function(accepted)
-  //   accepted - true/false returned from fn
-  done // on done function(result)
-  // result - filtered array
-) => {
-  let result = [];
-  let counter = 0;
-
-  function finish() {
-    // Callbacks might be called in any possible order,
-    // hence sort the filtered array
-    // by element's index in the original itemsection
-    result.sort((x, y) => x.index - y.index);
-
-    // Only value is needed in resulting array
-    result = result.map(x => x.value);
-
-    // Return a result using callback;
-    if (done) done(result);
-  }
-
-  items.forEach((value, index) => {
-    fn(value, (accepted) => {
-      if (accepted) result.push({ index, value });
-      if (++counter === items.length) finish();
-    });
-  });
-};
-
 metasync.find = (
   // Asynchronous find (iterate in series)
   // find :: [a] -> (a -> (Boolean -> Void) -> Void) -> (a -> Void)
@@ -413,134 +383,6 @@ metasync.find = (
 
   if (len > 0) next();
   else if (done) done();
-};
-
-metasync.series = (
-  // Asynchronous series
-  items, // incoming array
-  fn, // function(value, callback)
-  // value - item from items array
-  // callback - callback function(accepted)
-  //   err - instance of Error or null
-  done // on done function(result)
-  // err - instance of Error or null
-) => {
-  let i = -1;
-  const len = items.length;
-
-  function next() {
-    i++;
-    if (i >= len) {
-      if (done) done();
-      return;
-    }
-    fn(items[i], (err) => {
-      if (err instanceof Error) {
-        if (done) done(err);
-        return;
-      }
-      setImmediate(next);
-    });
-  }
-
-  next();
-};
-
-metasync.each = (
-  // Asynchronous each (iterate in parallel)
-  items, // incoming array
-  fn, // function(value, callback)
-  // value - item from items array
-  // callback - callback function(accepted)
-  //   err - instance of Error or null
-  done // on `done` function(result)
-  // err - instance of Error or null
-) => {
-  let counter = 0;
-  let finished = false;
-  const len = items.length;
-
-  if (len < 1) {
-    if (done) done();
-    return;
-  }
-  items.forEach((item) => {
-    fn(item, (err) => {
-      if (err instanceof Error) {
-        if (!finished) {
-          if (done) done(err);
-        }
-        finished = true;
-      } else {
-        counter++;
-        if (counter >= len) {
-          if (done) done();
-        }
-      }
-    });
-  });
-};
-
-metasync.reduce = (
-  // Asynchronous reduce
-  items, //   items - incoming array
-  callback, //   callback - function to be executed for each value in the array
-  //     previous - value previously returned in the last iteration
-  //     current - current element being processed in the array
-  //     callback - callback for returning value back to function reduce
-  //     counter - the index of the current element being processed in the array
-  //     items - the array reduce was called upon
-  done, //   done - callback function on done
-  //     err - error or null
-  //     data - result if !err
-  initial // optional value to be used as first arpument in first iteration
-) => {
-  let counter = typeof(initial) === 'undefined' ? 1 : 0;
-  let previous = counter === 1 ? items[0] : initial;
-  let current = items[counter];
-
-  function response(err, data) {
-    if (err || counter === items.length - 1) {
-      if (done) done(err, data);
-      return;
-    }
-    counter++;
-    previous = data;
-    current = items[counter];
-    callback(previous, current, response, counter, items);
-  }
-
-  callback(previous, current, response, counter, items);
-};
-
-metasync.map = (
-  // Asynchronous map
-  items, // incoming array
-  callback, // function to be executed for each value in the array
-  // current - current element being processed in the array
-  // callback - callback for returning value back to function map
-  //   err - error or null
-  //   value - result
-  done // callback function on done
-  // err - error or null
-  // data - result if !err
-) => {
-  const result = [];
-  let hadError = false;
-  let count = 0;
-  items.forEach((item, index) => {
-    callback(item, (err, value) => {
-      if (err) {
-        hadError = true;
-        return done(err);
-      }
-      if (hadError) return;
-      result[index] = value;
-      if (++count === items.length) {
-        done(null, result);
-      }
-    });
-  });
 };
 
 metasync.throttle = (
@@ -590,3 +432,10 @@ metasync.timeout = (
     }
   });
 };
+
+metasync.for = (
+  // Create an AsyncArray instance
+  array  // an array or a promise that resolves to an array
+) => (
+  new AsyncArray(array)
+);


### PR DESCRIPTION
This is a proof-of-concept implementation of the new chainable and thenable asynchronous array transformation mechanism.

Changes summary:

 * Add new `AsyncArray` class which is an abstraction of an asynchronously retrieved array that can be transformed or iterated with asynchronous functions.
 * Add new `metasync.for(arrayOrPromise)` function to instantiate an `AsyncArray`.
 * Move array-related metasync functions to a separate module to avoid cyclic dependency.
 * Add a simple test.

TODO list:

 * Investigate the performance cost of such solution, maybe it can be a lightweight thenable without the need for full-blown promises, or there may be other possible optimizations.
 * Maybe implement a similar mechanism for any iterable objects, not just arrays.
 * Maybe support functions returning promises as callbacks of `AsyncArray` methods.

Refs: https://github.com/metarhia/MetaSync/issues/17#issuecomment-280790478
Refs: https://github.com/metarhia/MetaSync/issues/37