### PR TITLE
Use lexically-scoped this in arrow function

### DIFF
--- a/lib/collectors.js
+++ b/lib/collectors.js
@@ -16,11 +16,10 @@ module.exports = (api) => {
       timeout: null,
       done: null
     };
-    const collector = this;
     if (this.timeout) {
       this.timer = setTimeout(() => {
         const err = new Error('DataCollector timeout');
-        collector.emit('timeout', err, collector.data);
+        this.emit('timeout', err, this.data);
       }, timeout);
     }
   };


### PR DESCRIPTION
Remove a useless reminiscent of ES5 in the DataCollector constructor.