### PR TITLE
Implement reduceRightLazy function

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -113,6 +113,42 @@ module.exports = (api) => {
     callback(previous, current, response, count, items);
   };
 
+  api.metasync.reduceRightLazy = (
+    // Asynchronous reduceRight with lazy evaluation
+    items, //   items - incoming array
+    callback, // callback - function to be executed for each value in array
+    //     previous - function returning value created
+    //       by iterating through right side of array from current element
+    //     current - current element being processed in the array
+    //     callback - callback for returning value back to function reduce
+    //     counter - index of the current element being processed in array
+    //     items - the array reduce was called upon
+    done, // optional on done callback function(err, result)
+    //   err - error or null
+    //   result - value created through iterating the array
+    initial // optional value to be used as first arpument in first iteration
+  ) => {
+    const len = items.length;
+    let count = 0;
+    let current = items[0];
+
+    function prevValue(response) {
+      count++;
+      if (count < len - 1) {
+        callback(prevValue, items[count], response, count, items);
+      } else {
+        current = items[count];
+        if (typeof(initial) === 'undefined') {
+          response(null, current);
+        } else {
+          callback(f => f(initial), current, response, count, items);
+        }
+      }
+    }
+
+    callback(prevValue, current, done, count, items);
+  };
+
   api.metasync.each = (
     // Asynchronous each (iterate in parallel)
     items, // incoming array

--- a/tests/examples.js
+++ b/tests/examples.js
@@ -348,6 +348,46 @@ function reduceTest(end) {
 
 }
 
+// Asyncronous reduceRightLazy (sequential)
+
+function reduceRightLazyTest(end) {
+
+  metasync.reduceRightLazy(
+    ['a', 'b', 'c'],
+    (getPrev, curr, callback) => getPrev((err, prev) => {
+      console.dir({ reduceRightLazy: { prev, curr } });
+      callback(null, curr);
+    }),
+    (/*err, data*/) => {
+      console.log('ReduceRightLazy test done');
+      end();
+    }
+  );
+
+}
+
+function reduceRightLazyEvalPartOfListTest(end) {
+  metasync.reduceRightLazy(
+    ['a', 'b', 'c', 'd', 'e', 'f'],
+    (getPrev, curr, callback, index) => {
+      if (index < 3) {
+        getPrev((err, prev) => {
+          console.dir({ reduceRightLazy: { prev, curr } });
+          callback(null, curr);
+        });
+      } else {
+        console.dir({ reduceRightLazy: { curr } });
+        callback(null, curr);
+      }
+    },
+    (/*err, data*/) => {
+      console.log('ReduceRightLazyEvalPartOfList test done');
+      end();
+    }
+  );
+
+}
+
 function concurrentQueueTest(end) {
 
   const queue =  new metasync.ConcurrentQueue(3, 2000);
@@ -531,6 +571,8 @@ metasync.composition([
   eachTest,
   seriesTest,
   reduceTest,
+  reduceRightLazyTest,
+  reduceRightLazyEvalPartOfListTest,
   concurrentQueueTest,
   concurrentQueuePauseResumeStopTest,
   throttleTest,


### PR DESCRIPTION
Brief: Because of lazy evaluation in Haskell `reduceRight` can iterate only through part of list if possible. 

![Evaluation tree for `reduceRight`](https://cloud.githubusercontent.com/assets/10159037/25044334/d038a4d8-212e-11e7-8209-4f91353a5404.jpg)
There are two ways for evaluating result of `reduceRight`:
1. Starting from bottom-right. This way is used in Javascript and always iterates through all array.
2. Starting from up-left. This way is used in Haskell. It uses recursive `func` calls which use non-constant memory amount but can stop iterating if result of lower triangle is not used.

To simulate this in Javascript I use `prevValue(prev => ...)` function which takes function which processing prev. If that function didn't execute then lower-righter part would not evaluated so it stop iterating

That function doesn't seem naturally for Javascript. Also the syntax has no do-notation so it isn't simple as it can be. Maybe after implementing async functions as monads it can be improved. 