### PR TITLE
Use for instead of forEach

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -23,18 +23,21 @@ module.exports = (api) => {
 
     if (!len) done(null, result);
 
-    items.forEach((item, index) => {
-      fn(item, (err, value) => {
-        if (errored) return;
-        if (err) {
-          errored = true;
-          return done(err);
-        }
-        result[index] = value;
-        count++;
-        if (count === len) done(null, result);
-      });
-    });
+    const next = (index, err, value) => {
+      if (errored) return;
+      if (err) {
+        errored = true;
+        return done(err);
+      }
+      result[index] = value;
+      count++;
+      if (count === len) done(null, result);
+    };
+
+    let i;
+    for (i = 0; i < len; i++) {
+      fn(items[i], next.bind(null, i));
+    }
   };
 
   api.metasync.filter = (
@@ -71,18 +74,21 @@ module.exports = (api) => {
       done(null, result);
     }
 
-    items.forEach((value, index) => {
-      fn(value, (err, accepted) => {
-        if (errored) return;
-        if (err) {
-          errored = true;
-          return done(err);
-        }
-        if (accepted) result.push({ index, value });
-        count++;
-        if (count === len) finish();
-      });
-    });
+    const next = (index, err, accepted) => {
+      if (errored) return;
+      if (err) {
+        errored = true;
+        return done(err);
+      }
+      if (accepted) result.push({ index, value: items[index] });
+      count++;
+      if (count === len) finish();
+    };
+
+    let i;
+    for (i = 0; i < len; i++) {
+      fn(items[i], next.bind(null, i));
+    }
   };
 
   api.metasync.reduce = (
@@ -132,21 +138,25 @@ module.exports = (api) => {
   ) => {
     const len = items.length;
     let count = 0;
-    let finished = false;
+    let errored = false;
     done = api.metasync.cb(done);
 
+    const next = (err) => {
+      if (errored) return;
+      if (err) {
+        errored = true;
+        done(err);
+      } else {
+        count++;
+        if (count >= len) done();
+      }
+    };
+
     if (len < 1) return done();
-    items.forEach((item) => {
-      fn(item, (err) => {
-        if (err instanceof Error) {
-          if (!finished) done(err);
-          finished = true;
-        } else {
-          count++;
-          if (count >= len) done();
-        }
-      });
-    });
+    let i;
+    for (i = 0; i < len; i++) {
+      fn(items[i], next);
+    }
   };
 
   api.metasync.series = (


### PR DESCRIPTION
As it was requested in #56 this PR changes all usages of `Array.forEach()` to `for`