### PR TITLE
Fix done not being called on an empty array

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -21,6 +21,8 @@ module.exports = (api) => {
     let count = 0;
     done = api.metasync.cb(done);
 
+    if (!len) done(null, result);
+
     items.forEach((item, index) => {
       fn(item, (err, value) => {
         if (errored) return;
@@ -53,6 +55,8 @@ module.exports = (api) => {
     let count = 0;
     let errored = false;
     done = api.metasync.cb(done);
+
+    if (!len) done(null, result);
 
     function finish() {
       // Callbacks might be called in any possible order,
@@ -96,10 +100,13 @@ module.exports = (api) => {
     initial // optional value to be used as first arpument in first iteration
   ) => {
     const len = items.length;
+    done = api.metasync.cb(done);
+
+    if (!len) done(null);
+
     let count = typeof(initial) === 'undefined' ? 1 : 0;
     let previous = count === 1 ? items[0] : initial;
     let current = items[count];
-    done = api.metasync.cb(done);
 
     function response(err, data) {
       if (err) return done(err);


### PR DESCRIPTION
This situation was not handled in such functions:
* `map()`
* `filter()`
* `reduce()`