### PR TITLE
Remove redundant check in flow

### DIFF
--- a/lib/flow.js
+++ b/lib/flow.js
@@ -44,15 +44,13 @@ module.exports = (api) => {
   ) => {
     const len = fns.length;
     let counter = 0;
-    let finished = false;
     done = api.metasync.cb(done);
 
     if (len < 1) return done(null, data);
     const finishFn = (fn, err, result) => {
       if (fn.name && result) data[fn.name] = result;
       if (err) {
-        if (!finished) done(err);
-        finished = true;
+        done(err);
       } else if (++counter >= len) {
         done(null, data);
       }


### PR DESCRIPTION
`metasync.cb` checks if function has already finished