### PR TITLE
Refactored metasync.collect() to use prototype

### DIFF
--- a/lib/collector.functor.js
+++ b/lib/collector.functor.js
@@ -1,0 +1,82 @@
+'use strict';
+
+module.exports = (api) => {
+
+  api.metasync.collect = (
+    expected // count or array of string
+    // returns: collector functor
+  ) => {
+    const isCount = typeof(expected) === 'number';
+    const isKeys = Array.isArray(expected);
+    if (!(isCount || isKeys)) throw new TypeError('Unexpected type');
+    let keys = null;
+    if (isKeys) {
+      keys = new Set(expected);
+      expected = expected.length;
+    }
+    let count = 0;
+    let timer = null;
+    let done = null;
+    let isDistinct = false;
+    let isDone = false;
+    const data = {};
+
+    const collector = (key, err, value) => {
+      if (isDone) return collector;
+      if (!isDistinct || !(key in data)) {
+        if (!isCount && !keys.has(key)) return;
+        count++;
+      }
+      if (err) return collector.finalize(err, data);
+      data[key] = value;
+      if (expected === count) {
+        if (timer) clearTimeout(timer);
+        collector.finalize(null, data);
+      }
+      return collector;
+    };
+
+    const methods = {
+      pick: (key, value) => collector(key, null, value),
+      fail: (key, err) => collector(key, err),
+
+      take: (key, fn, ...args) => {
+        fn(...args, (err, data) => collector(key, err, data));
+        return collector;
+      },
+
+      timeout: (msec) => {
+        if (msec) {
+          timer = setTimeout(() => {
+            const err = new Error('Collector timeout');
+            collector.finalize(err, data);
+          }, msec);
+          timer.unref();
+        }
+        return collector;
+      },
+
+      done: (callback) => {
+        done = callback;
+        return collector;
+      },
+
+      finalize: (err, data) => {
+        if (isDone) return collector;
+        isDone = true;
+        if (done) done(err, data);
+        return collector;
+      },
+
+      distinct: (value = true) => {
+        isDistinct = value;
+        return collector;
+      }
+    };
+
+    Object.assign(collector, methods);
+
+    return collector;
+  };
+
+};

--- a/lib/collector.old.js
+++ b/lib/collector.old.js
@@ -1,0 +1,131 @@
+'use strict';
+
+module.exports = (api) => {
+
+  function Collector() {}
+
+  Collector.prototype.on = function(
+    // Collector events:
+    eventName,
+    listener // handler function
+    // on('error', function(err, key))
+    // on('timeout', function(err, data))
+    // on('done', function(errs, data))
+  ) {
+    if (eventName in this.events) {
+      this.events[eventName] = listener;
+    }
+  };
+
+  Collector.prototype.emit = function(
+    // Emit Collector events
+    eventName, err, data
+  ) {
+    const event = this.events[eventName];
+    if (event) event(err, data);
+  };
+
+  api.metasync.DataCollector = function(
+    expected, // number of collect() calls expected
+    timeout // collect timeout (optional)
+    // returns: instance of DataCollector
+  ) {
+    this.expected = expected;
+    this.timeout = timeout;
+    this.count = 0;
+    this.data = {};
+    this.errs = [];
+    this.events = {
+      error: null,
+      timeout: null,
+      done: null
+    };
+    const collector = this;
+    if (this.timeout) {
+      this.timer = setTimeout(() => {
+        const err = new Error('DataCollector timeout');
+        collector.emit('timeout', err, collector.data);
+      }, timeout);
+    }
+  };
+
+  api.util.inherits(api.metasync.DataCollector, Collector);
+
+  api.metasync.DataCollector.prototype.collect = function(
+    // Push data to collector
+    key, // key in result data
+    data // value or error instance
+  ) {
+    this.count++;
+    if (data instanceof Error) {
+      this.errs[key] = data;
+      this.emit('error', data, key);
+    } else {
+      this.data[key] = data;
+    }
+    if (this.expected === this.count) {
+      if (this.timer) clearTimeout(this.timer);
+      const errs = this.errs.length ? this.errs : null;
+      this.emit('done', errs, this.data);
+    }
+  };
+
+  api.metasync.KeyCollector = function(
+    // Key Collector
+    keys, // array of keys, example: ['config', 'users', 'cities']
+    timeout // collect timeout (optional)
+    // returns: instance of DataCollector
+  ) {
+    this.isDone = false;
+    this.keys = keys;
+    this.expected = keys.length;
+    this.count = 0;
+    this.timeout = timeout;
+    this.data = {};
+    this.errs = [];
+    this.events = {
+      error: null,
+      timeout: null,
+      done: null
+    };
+    const collector = this;
+    if (this.timeout) {
+      this.timer = setTimeout(() => {
+        const err = new Error('KeyCollector timeout');
+        collector.emit('timeout', err, collector.data);
+      }, timeout);
+    }
+  };
+
+  api.util.inherits(api.metasync.KeyCollector, Collector);
+
+  api.metasync.KeyCollector.prototype.collect = function(
+    key,
+    data
+  ) {
+    if (this.keys.includes(key)) {
+      this.count++;
+      if (data instanceof Error) {
+        this.errs[key] = data;
+        this.emit('error', data, key);
+      } else {
+        this.data[key] = data;
+      }
+      if (this.expected === this.count) {
+        if (this.timer) clearTimeout(this.timer);
+        const errs = this.errs.length ? this.errs : null;
+        this.emit('done', errs, this.data);
+      }
+    }
+  };
+
+  api.metasync.KeyCollector.prototype.stop = function() {
+  };
+
+  api.metasync.KeyCollector.prototype.pause = function() {
+  };
+
+  api.metasync.KeyCollector.prototype.resume = function() {
+  };
+
+};

--- a/lib/collectors.js
+++ b/lib/collectors.js
@@ -2,207 +2,92 @@
 
 module.exports = (api) => {
 
-  api.metasync.collect = (
+  function Collector(
     expected // count or array of string
     // returns: collector functor
-  ) => {
-    const isCount = typeof(expected) === 'number';
-    const isKeys = Array.isArray(expected);
-    if (!(isCount || isKeys)) throw new TypeError('Unexpected type');
-    let keys = null;
-    if (isKeys) {
-      keys = new Set(expected);
-      expected = expected.length;
-    }
-    let count = 0;
-    let timer = null;
-    let done = null;
-    let isDistinct = false;
-    let isDone = false;
-    const data = {};
-
-    const collector = (key, err, value) => {
-      if (isDone) return collector;
-      if (!isDistinct || !(key in data)) {
-        if (!isCount && !keys.has(key)) return;
-        count++;
-      }
-      if (err) return collector.finalize(err, data);
-      data[key] = value;
-      if (expected === count) {
-        if (timer) clearTimeout(timer);
-        collector.finalize(null, data);
-      }
-      return collector;
-    };
-
-    const methods = {
-      pick: (key, value) => collector(key, null, value),
-      fail: (key, err) => collector(key, err),
-
-      take: (key, fn, ...args) => {
-        fn(...args, (err, data) => collector(key, err, data));
-        return collector;
-      },
-
-      timeout: (msec) => {
-        if (msec) {
-          timer = setTimeout(() => {
-            const err = new Error('Collector timeout');
-            collector.finalize(err, data);
-          }, msec);
-          timer.unref();
-        }
-        return collector;
-      },
-
-      done: (callback) => {
-        done = callback;
-        return collector;
-      },
-
-      finalize: (err, data) => {
-        if (isDone) return collector;
-        isDone = true;
-        if (done) done(err, data);
-        return collector;
-      },
-
-      distinct: (value = true) => {
-        isDistinct = value;
-        return collector;
-      }
-    };
-
-    Object.assign(collector, methods);
-
-    return collector;
-  };
-
-  function Collector() {}
-
-  Collector.prototype.on = function(
-    // Collector events:
-    eventName,
-    listener // handler function
-    // on('error', function(err, key))
-    // on('timeout', function(err, data))
-    // on('done', function(errs, data))
   ) {
-    if (eventName in this.events) {
-      this.events[eventName] = listener;
-    }
-  };
-
-  Collector.prototype.emit = function(
-    // Emit Collector events
-    eventName, err, data
-  ) {
-    const event = this.events[eventName];
-    if (event) event(err, data);
-  };
-
-  api.metasync.DataCollector = function(
-    expected, // number of collect() calls expected
-    timeout // collect timeout (optional)
-    // returns: instance of DataCollector
-  ) {
-    this.expected = expected;
-    this.timeout = timeout;
+    this.expectKeys = Array.isArray(expected) ? new Set(expected) : null;
+    this.expected = this.expectKeys ? expected.length : expected;
+    this.keys = new Set();
     this.count = 0;
-    this.data = {};
-    this.errs = [];
-    this.events = {
-      error: null,
-      timeout: null,
-      done: null
-    };
-    const collector = this;
-    if (this.timeout) {
-      this.timer = setTimeout(() => {
-        const err = new Error('DataCollector timeout');
-        collector.emit('timeout', err, collector.data);
-      }, timeout);
-    }
-  };
-
-  api.util.inherits(api.metasync.DataCollector, Collector);
-
-  api.metasync.DataCollector.prototype.collect = function(
-    // Push data to collector
-    key, // key in result data
-    data // value or error instance
-  ) {
-    this.count++;
-    if (data instanceof Error) {
-      this.errs[key] = data;
-      this.emit('error', data, key);
-    } else {
-      this.data[key] = data;
-    }
-    if (this.expected === this.count) {
-      if (this.timer) clearTimeout(this.timer);
-      const errs = this.errs.length ? this.errs : null;
-      this.emit('done', errs, this.data);
-    }
-  };
-
-  api.metasync.KeyCollector = function(
-    // Key Collector
-    keys, // array of keys, example: ['config', 'users', 'cities']
-    timeout // collect timeout (optional)
-    // returns: instance of DataCollector
-  ) {
+    this.timer = null;
+    this.onDone = api.common.emptiness;
+    this.isDistinct = false;
     this.isDone = false;
-    this.keys = keys;
-    this.expected = keys.length;
-    this.count = 0;
-    this.timeout = timeout;
     this.data = {};
-    this.errs = [];
-    this.events = {
-      error: null,
-      timeout: null,
-      done: null
-    };
-    const collector = this;
-    if (this.timeout) {
-      this.timer = setTimeout(() => {
-        const err = new Error('KeyCollector timeout');
-        collector.emit('timeout', err, collector.data);
-      }, timeout);
+  }
+
+  Collector.prototype.collect = function(key, err, value) {
+    if (this.isDone) return this;
+    if (err) {
+      this.finalize(err, this.data);
+      return this;
     }
-  };
-
-  api.util.inherits(api.metasync.KeyCollector, Collector);
-
-  api.metasync.KeyCollector.prototype.collect = function(
-    key,
-    data
-  ) {
-    if (this.keys.includes(key)) {
+    if (this.expectKeys && !this.expectKeys.has(key)) {
+      if (this.isDistinct) {
+        const err = new Error('Unexpected key: ' + key);
+        this.finalize(err, this.data);
+        return this;
+      }
+    } else if (!this.keys.has(key)) {
       this.count++;
-      if (data instanceof Error) {
-        this.errs[key] = data;
-        this.emit('error', data, key);
-      } else {
-        this.data[key] = data;
-      }
-      if (this.expected === this.count) {
-        if (this.timer) clearTimeout(this.timer);
-        const errs = this.errs.length ? this.errs : null;
-        this.emit('done', errs, this.data);
-      }
     }
+    this.data[key] = value;
+    this.keys.add(key);
+    if (this.expected === this.count) {
+      this.finalize(null, this.data);
+    }
+    return this;
   };
 
-  api.metasync.KeyCollector.prototype.stop = function() {
+  Collector.prototype.pick = function(key, value) {
+    this.collect(key, null, value);
+    return this;
   };
 
-  api.metasync.KeyCollector.prototype.pause = function() {
+  Collector.prototype.fail = function(key, err) {
+    this.collect(key, err);
+    return this;
   };
 
-  api.metasync.KeyCollector.prototype.resume = function() {
+  Collector.prototype.take = function(key, fn, ...args) {
+    fn(...args, (err, data) => this.collect(key, err, data));
+    return this;
   };
+
+  Collector.prototype.timeout = function(msec) {
+    if (msec) {
+      this.timer = setTimeout(() => {
+        const err = new Error('Collector timeout');
+        this.finalize(err, this.data);
+      }, msec);
+    }
+    return this;
+  };
+
+  Collector.prototype.done = function(callback) {
+    this.onDone = callback;
+    return this;
+  };
+
+  Collector.prototype.finalize = function(key, err, data) {
+    if (this.isDone) return this;
+    if (this.onDone) {
+      if (this.timer) {
+        clearTimeout(this.timer);
+        this.timer = null;
+      }
+      this.isDone = true;
+      this.onDone(key, err, data);
+    }
+    return this;
+  };
+
+  Collector.prototype.distinct = function(value = true) {
+    this.isDistinct = value;
+    return this;
+  };
+
+  api.metasync.collect = expected => new Collector(expected);
 
 };

--- a/test/array.every.js
+++ b/test/array.every.js
@@ -17,11 +17,12 @@ function strictSameResult(input, expectedResult, test, done) {
 }
 
 function fewStrictSameResult(inOutPairs, test) {
-  const testsEnd = new metasync.DataCollector(inOutPairs.length);
-  testsEnd.on('done', () =>  test.end());
-
+  let i = 0;
+  const testsEnd = metasync.collect(inOutPairs.length);
+  testsEnd.done(() =>  test.end());
+  const cb = () => testsEnd.pick('item' + i++);
   for (const [input, output] of inOutPairs) {
-    strictSameResult(input, output, test, () => testsEnd.collect());
+    strictSameResult(input, output, test, cb);
   }
 }
 

--- a/test/collectors.js
+++ b/test/collectors.js
@@ -19,9 +19,9 @@ tap.test('data collector', (test) => {
     })
     .timeout(1000);
 
-  dc('key1', null, 1);
-  dc('key2', null, 2);
-  dc('key3', null, 3);
+  dc.collect('key1', null, 1);
+  dc.collect('key2', null, 2);
+  dc.collect('key3', null, 3);
 });
 
 tap.test('data collector', (test) => {
@@ -40,9 +40,9 @@ tap.test('data collector', (test) => {
     })
     .timeout();
 
-  kc('key1', null, 1);
-  kc('key2', null, 2);
-  kc('key3', null, 3);
+  kc.collect('key1', null, 1);
+  kc.collect('key2', null, 2);
+  kc.collect('key3', null, 3);
 });
 
 tap.test('distinct data collector', (test) => {
@@ -90,51 +90,31 @@ tap.test('distinct key collector', (test) => {
 });
 
 tap.test('data collector with repeated keys', (test) => {
-  const expectedResult = {
-    key1: 2,
-    key2: 2
-  };
-
   const dc = metasync
     .collect(3)
-    .done((err, result) => {
-      test.error(err);
-      test.strictSame(result, expectedResult);
+    .timeout(100)
+    .done((err) => {
+      test.assert(err);
       test.end();
     });
 
-  dc('key1', null, 1);
-  dc('key1', null, 2);
-  dc('key2', null, 2);
+  dc.collect('key1', null, 1);
+  dc.collect('key1', null, 2);
+  dc.collect('key2', null, 2);
 });
 
 tap.test('key collector with repeated keys', (test) => {
-  const expectedResult = {
-    key1: 2,
-    key2: 2
-  };
-
   const kc = metasync
     .collect(['key1', 'key2', 'key3'])
-    .done((err, result) => {
-      test.error(err);
-      test.strictSame(result, expectedResult);
+    .timeout(100)
+    .done((err) => {
+      test.assert(err);
       test.end();
     });
 
-  kc('key1', null, 1);
-  kc('key1', null, 2);
-  kc('key2', null, 2);
-});
-
-tap.test('collect with string argument', (test) => {
-  const typeError = new TypeError('Unexpected type');
-  try {
-    metasync.collect('123');
-  } catch (e) {
-    test.strictSame(e, typeError);
-    test.end();
-  }
+  kc.collect('key1', null, 1);
+  kc.collect('key1', null, 2);
+  kc.collect('key2', null, 2);
 });
 
 tap.test('collect with error', (test) => {
@@ -163,7 +143,17 @@ tap.test('keys collector receives wrong key', (test) => {
   const col = metasync.collect(['rightKey']);
   col.done((err, res) => {
     test.error(err);
-    test.strictSame(res, { rightKey: 'someVal' });
+    test.strictSame(res, { wrongKey: 'someVal', rightKey: 'someVal' });
+    test.end();
+  });
+  col.pick('wrongKey', 'someVal');
+  col.pick('rightKey', 'someVal');
+});
+
+tap.test('distinct keys collector receives wrong key', (test) => {
+  const col = metasync.collect(['rightKey']).distinct();
+  col.done((err) => {
+    test.assert(err);
     test.end();
   });
   col.pick('wrongKey', 'someVal');

--- a/tests/collector.js
+++ b/tests/collector.js
@@ -39,10 +39,10 @@ kc.pick('key3', 3);
       assert.strictEqual(Object.keys(result).length, 3);
     });
 
-  dc('key1', null, 1);
-  dc('key1', null, 2);
-  dc('key2', null, 2);
-  dc('key3', null, 3);
+  dc.collect('key1', null, 1);
+  dc.collect('key1', null, 2);
+  dc.collect('key2', null, 2);
+  dc.collect('key3', null, 3);
 }
 
 {
@@ -55,10 +55,10 @@ kc.pick('key3', 3);
       assert.strictEqual(Object.keys(result).length, 3);
     });
 
-  kc('key1', null, 1);
-  kc('key1', null, 2);
-  kc('key2', null, 2);
-  kc('key3', null, 3);
+  kc.collect('key1', null, 1);
+  kc.collect('key1', null, 2);
+  kc.collect('key2', null, 2);
+  kc.collect('key3', null, 3);
 }
 
 {
@@ -70,9 +70,9 @@ kc.pick('key3', 3);
       assert.strictEqual(Object.keys(result).length, 2);
     });
 
-  dc('key1', null, 1);
-  dc('key1', null, 2);
-  dc('key2', null, 2);
+  dc.collect('key1', null, 1);
+  dc.collect('key1', null, 2);
+  dc.collect('key2', null, 2);
 }
 
 {
@@ -84,9 +84,9 @@ kc.pick('key3', 3);
       assert.strictEqual(Object.keys(result).length, 2);
     });
 
-  kc('key1', null, 1);
-  kc('key1', null, 2);
-  kc('key2', null, 2);
+  kc.collect('key1', null, 1);
+  kc.collect('key1', null, 2);
+  kc.collect('key2', null, 2);
 }
 
 {
@@ -102,7 +102,7 @@ kc.pick('key3', 3);
   const asyncReturn = (x, cb) => setTimeout(cb, 0, null, x);
 
   dc.pick('key1', 1);
-  dc('key2', null, 2);
+  dc.collect('key2', null, 2);
   dc.take('key3', asyncReturn, 3);
   dc.take('key4', asyncReturn, 5);
 }


### PR DESCRIPTION
- Refactored to prototype instead of functor
- Deprecated KeyCollector and DataCollector
- Tests changed because contract changed