### PR TITLE
Saving flow results to an array

### DIFF
--- a/lib/flow.js
+++ b/lib/flow.js
@@ -32,7 +32,7 @@ const flow = (
     if (timeout) {
       timer = setTimeout(() => {
         timer = null;
-        finish(new Error('Timeout'));
+        finish(new Error('Flow timed out'));
       }, timeout);
     }
     paused = false;
@@ -94,6 +94,7 @@ function parallel(
     data = {};
   }
   const done = common.cb(callback);
+  const isArray = Array.isArray(data);
   const len = fns.length;
   if (len === 0) {
     done(null, data);
@@ -106,7 +107,10 @@ function parallel(
       done(err);
       return;
     }
-    if (fn.name && result) data[fn.name] = result;
+    if (result !== data) {
+      if (isArray) data.push(result);
+      else if (fn.name) data[fn.name] = result;
+    }
     if (++counter === len) done(null, data);
   };
 
@@ -131,6 +135,7 @@ function sequential(
     data = {};
   }
   const done = common.cb(callback);
+  const isArray = Array.isArray(data);
   const len = fns.length;
   if (len === 0) {
     done(null, data);
@@ -141,7 +146,10 @@ function sequential(
   function next() {
     let fn = null;
     const finish = (err, result) => {
-      if (fn.name && result) data[fn.name] = result;
+      if (result !== data) {
+        if (isArray) data.push(result);
+        else if (fn.name) data[fn.name] = result;
+      }
       if (err) {
         done(err);
         return;

--- a/test/flow.js
+++ b/test/flow.js
@@ -245,3 +245,36 @@ tap.test('flow cancel after end', (test) => {
   }, 100);
 
 });
+
+tap.test('flow to array', (test) => {
+
+  let count = 0;
+
+  function fn1(data, cb) {
+    count++;
+    process.nextTick(() => cb(null, 'data 1'));
+  }
+
+  function fn2(data, cb) {
+    count++;
+    process.nextTick(() => cb(null, 'data 2'));
+  }
+
+  function fn3(cb) {
+    count++;
+    process.nextTick(() => cb(null, 'data 3'));
+  }
+
+  function fn4(cb) {
+    count++;
+    process.nextTick(() => cb(null, 'data 4'));
+  }
+
+  const fc = metasync.flow([fn1, [[fn2, fn3]], fn4]);
+  fc(['data 0'], (err, data) => {
+    test.strictSame(data, ['data 0', 'data 1', 'data 2', 'data 3', 'data 4']);
+    test.strictSame(count, 4);
+    test.end();
+  });
+
+});


### PR DESCRIPTION
If we pass [] to async function (composed by flow) instead of {} it will collect
results pushing them to an array. Sequential composition will push results in
sequential order but parallel composition will push results randomly.

Closes: https://github.com/metarhia/metasync/issues/203