### PR TITLE
Add runIf() shortcut to run async function when it is provided

### DIFF
--- a/lib/control.js
+++ b/lib/control.js
@@ -120,9 +120,19 @@ const runIf = (condition, defaultVal, asyncFn, ...args) => {
   }
 };
 
+// Run `asyncFn` if it is provided
+// Signature: asyncFn, ...args
+//   asyncFn - <Function>, callback-last function that will be executed if it
+//       is provided
+//   args - <any[]>, args to pass to `asyncFn`
+const runIfFn = (asyncFn, ...args) => {
+  runIf(asyncFn, undefined, asyncFn, ...args);
+};
+
 module.exports = {
   firstOf,
   parallel,
   sequential,
   runIf,
+  runIfFn,
 };

--- a/test/control.js
+++ b/test/control.js
@@ -134,3 +134,21 @@ metatests.test('runIf forward an error', test => {
     test.end();
   });
 });
+
+metatests.test('runIfFn', test => {
+  test.plan(5);
+  const value = 42;
+  const asyncFn = cb => {
+    cb(null, value);
+  };
+
+  metasync.runIfFn(test.mustCall(asyncFn), (err, res) => {
+    test.error(err);
+    test.strictSame(res, value);
+  });
+
+  metasync.runIfFn(null, (err, res) => {
+    test.error(err);
+    test.assertNot(res);
+  });
+});


### PR DESCRIPTION
The test will probably fail due to a bug in `metatests`.
/cc @lundibundi 