### PR TITLE
Call original debounced function with proper "this" context

### DIFF
--- a/lib/throttle.js
+++ b/lib/throttle.js
@@ -39,15 +39,16 @@ const throttle = (timeout, fn, ...args) => {
 //   args - <Array>, arguments for fn, optional
 const debounce = (timeout, fn, ...args) => {
   let timer;
-
-  const debounced = () => (args ? fn(...args) : fn());
-
-  const wrapped = () => {
-    if (timer) clearTimeout(timer);
-    timer = setTimeout(debounced, timeout);
+  return function () {
+    if (timer?.refresh !== undefined) {
+      // if possible, refresh the timer without
+      // allocating a new JavaScript object
+      timer.refresh();
+    } else {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(this, args), timeout);
+    }
   };
-
-  return wrapped;
 };
 
 const FN_TIMEOUT = 'Metasync: asynchronous function timed out';

--- a/test/throttle.js
+++ b/test/throttle.js
@@ -101,6 +101,30 @@ metatests.test('debounce without arguments for function', (test) => {
   test.strictSame(count, 0);
 });
 
+metatests.test('debounce with proper "this" binding', (test) => {
+  let count = 0;
+  let originalThis;
+
+  class DebounceTest {
+    constructor() {
+      this.debouncedMethod = metasync.debounce(1, this.originalMethod);
+      originalThis = this;
+    }
+
+    originalMethod(...args) {
+      test.strictSame(args, []);
+      test.strictSame(this, originalThis);
+      count++;
+      test.end();
+    }
+  }
+
+  const debounceTestInstance = new DebounceTest();
+  debounceTestInstance.debouncedMethod();
+  debounceTestInstance.debouncedMethod();
+  test.strictSame(count, 0);
+});
+
 metatests.test('timeout with sync function', (test) => {
   const syncFn = (callback) => callback(null, 'someVal');
   metasync.timeout(1, syncFn, (err, res, ...args) => {


### PR DESCRIPTION
- [X] tests and linter show no problems (`npm t`)
- [X] tests are added/updated for bug fixes and new features
- [X] code is properly formatted (`npm run fmt`)